### PR TITLE
Remove a private repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   "dependencies": {
     "argparse": "^1.0.10",
     "facebook-chat-api": "github:AstroCB/facebook-chat-api#lookup-by-mid",
-    "fca-unofficial": "github:fca-unofficial/fca-unofficial",
     "memjs": "^1.2.2"
   },
   "devDependencies": {


### PR DESCRIPTION
fca-unofficial is a private repository and we don't need it anymore